### PR TITLE
38 Fix unexpected '' (T_ENCAPSED_AND_WHITESPACE)

### DIFF
--- a/classes/client.php
+++ b/classes/client.php
@@ -198,7 +198,7 @@ class client {
                 </head>
                 <body></body>
                 </html>
-            EOD;
+EOD;
             die($js);
         }
     }
@@ -401,7 +401,7 @@ class client {
                 </head>
                 <body></body>
                 </html>
-            EOD;
+EOD;
             die($js);
         }
     }


### PR DESCRIPTION
Change HEREDOC strings to be compatible with PHP versions before 7.3. Prior to PHP 7.3.0, the closing identifier must begin in the first column of the line.